### PR TITLE
Update bbhtv2.1.sh

### DIFF
--- a/bbhtv2.1.sh
+++ b/bbhtv2.1.sh
@@ -449,7 +449,7 @@ echo "${GREEN} [+] Fingerprinting & CVE tools ${RESET}"
 {
 sudo pip3 install webtech
 go get -u github.com/projectdiscovery/chaos-client/cmd/chaos
-go get -u github.com/projectdiscovery/nuclei/v2/cmd/nuclei
+go get -u github.com/projectdiscovery/nuclei/cmd/nuclei
 git clone https://github.com/projectdiscovery/nuclei-templates ~/tools/nuclei-templates
 go get -u github.com/tomnomnom/gf
 


### PR DESCRIPTION
change nuclei installation command  go get -u github.com/projectdiscovery/nuclei/v2/cmd/nuclei with  go get -u github.com/projectdiscovery/nuclei/cmd/nuclei as the former causes error during installation on go 1.15