### PR TITLE
Minor Change: Remove unused Amass Version Constant

### DIFF
--- a/bbhtv2.1.sh
+++ b/bbhtv2.1.sh
@@ -5,10 +5,6 @@ GREEN=$(tput setaf 2)
 BLUE=$(tput setaf 4)
 RESET=$(tput sgr0)
 
-
-AMASS_VERSION=3.10.4
-
-
 echo "${RED} ######################################################### ${RESET}"
 echo "${RED} #                 TOOLS FOR BUG BOUNTY                  # ${RESET}"
 echo "${RED} ######################################################### ${RESET}"


### PR DESCRIPTION
Deleted entry for a unused constant for Amass as it has shifted to direct downloads using go get rendering the current constant illegitimate.